### PR TITLE
Unload yoast seo opengraph tags on shared graph page

### DIFF
--- a/includes/modules/Charts/Charts.php
+++ b/includes/modules/Charts/Charts.php
@@ -210,6 +210,17 @@ if (!function_exists('filter_presenters')) {
 			unset($filter[$key]);
 		}
 
+		if (($key = array_search('Yoast\WP\SEO\Presenters\Twitter\Card_Presenter', $filter)) !== false) {
+			unset($filter[$key]);
+		}
+
+		if (($key = array_search('Yoast\WP\SEO\Presenters\Twitter\Label_Presenter', $filter)) !== false) {
+			unset($filter[$key]);
+		}
+
+		if (($key = array_search('Yoast\WP\SEO\Presenters\Slack\Enhanced_Data_Presenter', $filter)) !== false) {
+			unset($filter[$key]);
+		}
 		return $filter;
 	}
 }


### PR DESCRIPTION
This adds support for the yoast seo open graph plugin along with our plugin. It also improves the readability by adding line breaks to our tags.
